### PR TITLE
Replace references to society accounts with group accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 *~
+
+.idea/
+.venv/

--- a/control/templates/base.html
+++ b/control/templates/base.html
@@ -78,7 +78,7 @@
             <h5>Membership</h5>
             <ul class="fa-ul">
               <li><a href="{{ url_for('signup.signup') }}"><i class="fa fa-li fa-user"></i> Join the SRCF</a></li>
-              <li><a href="{{ url_for('signup.newsoc') }}"><i class="fa fa-li fa-users"></i> Create society account</a></li>
+              <li><a href="{{ url_for('signup.newsoc') }}"><i class="fa fa-li fa-users"></i> Create group account</a></li>
               <li><a href="{{ DOMAIN_WEB }}/services"><i class="fa fa-li fa-cubes"></i> List of services</a></li>
               <li><a href="{{ DOMAIN_WEB }}/donate"><i class="fa fa-li fa-money"></i> Donate</a></li>
               <li><a href="{{ DOMAIN_WEB }}/tos"><i class="fa fa-li fa-balance-scale"></i> Terms of service</a></li>

--- a/control/templates/home.html
+++ b/control/templates/home.html
@@ -66,9 +66,9 @@
         <a href="{{ url_for('jobs.home') }}" class="btn btn-outline-secondary">Job history</a>
     </div>
 </div>
-<h3>Your society accounts</h3>
+<h3>Your group accounts</h3>
 {%- if member.societies %}
-    <p>You are currently listed as an administrator for {{ member.societies|length }} society account{{ "" if member.societies|length == 1 else "s" }}.</p>
+    <p>You are currently listed as an administrator for {{ member.societies|length }} group account{{ "" if member.societies|length == 1 else "s" }}.</p>
     <p><a href="{{ url_for('signup.newsoc') }}" class="btn btn-outline-primary">Create new</a></p>
     <div class="card-columns">
         {%- for soc in member.societies|sort(attribute='society') %}
@@ -135,7 +135,7 @@
         {%- endfor %}
     </div>
 {%- else %}
-    <p>You don't currently administrate any society accounts.</p>
+    <p>You don't currently administrate any group accounts.</p>
     <p><a href="{{ url_for('signup.newsoc') }}" class="btn btn-outline-primary">Create new</a></p>
 {%- endif %}
 {% endblock %}

--- a/control/templates/member/home.html
+++ b/control/templates/member/home.html
@@ -204,7 +204,7 @@ mysql&gt;</pre>
                         .
                     </p>
                     {%- if not member.mysqldbs %}
-                        <p>You don't currently have a personal database, most likely because a MySQL account was created for you to manage a society database.</p>
+                        <p>You don't currently have a personal database, most likely because a MySQL account was created for you to manage a group account database.</p>
                     {%- endif %}
                 </div>
             {%- elif member.mysqldbs %}
@@ -269,7 +269,7 @@ Type "help" for help.
                         </p>
                     {%- endif %}
                     {%- if not member.pgdbs %}
-                        <p>You don't currently have a personal database, most likely because a PostgreSQL account was created for you to manage a society database.</p>
+                        <p>You don't currently have a personal database, most likely because a PostgreSQL account was created for you to manage a group account database.</p>
                     {%- endif %}
                 </div>
             {%- elif member.pgdbs %}

--- a/control/templates/signup/newsoc.html
+++ b/control/templates/signup/newsoc.html
@@ -1,24 +1,24 @@
 {% extends "base.html" %}
 {% from "macros.html" import soc_desc_soc %}
 
-{% set page_title = "Create society account" %}
+{% set page_title = "Create group account" %}
 {% set page_parent = url_for('home.home') %}
 
 {% block body %}
-<p>To apply for a shared society account on the SRCF, please fill in the form below.  Once created, you'll be able to use the control panel to create any databases or mailing lists.</p>
-<p>Before applying, please ensure we don't already have an existing account for the same purpose.  You may wish to confirm with your predecessors (if representing an existing real-world group), or check our <a href="{{ DOMAIN_WEB }}/socs/">list of all society accounts</a>.  Multiple accounts for the same group are not permitted.</p>
-<p>Society accounts are identified by a <em>short name</em>, which will form part of your society website URL (<strong><span class="var">name</span>.soc.srcf.net</strong>) and mailing addresses (e.g. <strong><span class="var">name</span>-admins@srcf.net</strong>).</p>
-<p>Please note that all named users that wish to be administrators on the account must have their own personal SRCF accounts &ndash; if this is not the case, direct them to the <a href="{{ url_for('signup.signup') }}">signup form</a> to apply.</p>
+<p>To apply for a shared group account on the SRCF, please fill in the form below.  Once created, you'll be able to use the control panel to create any databases or mailing lists.</p>
+<p>Before applying, please ensure we don't already have an existing group account for the same purpose.  You may wish to confirm with your predecessors (if representing an existing real-world group), or check our <a href="{{ DOMAIN_WEB }}/socs/">list of all group accounts</a>.  Multiple accounts for the same group are not permitted.</p>
+<p>Group accounts are identified by a <em>short name</em>, which will form part of your group account website URL (<strong><span class="var">name</span>.soc.srcf.net</strong>) and mailing addresses (e.g. <strong><span class="var">name</span>-admins@srcf.net</strong>).</p>
+<p>Please note that all named users that wish to be administrators on the group account must have their own personal SRCF accounts &ndash; if this is not the case, direct them to the <a href="{{ url_for('signup.signup') }}">signup form</a> to apply.</p>
 {%- if errors.existing is defined %}
     <div class="card">
         <div class="card-body">
             <h5 class="card-title">{{ soc_desc_soc(errors.existing) }}</h5>
-            <p>This society name is already in use.  <span class="text-danger">If this represents you, <strong>don't submit this form!</strong></span></p>
+            <p>This group name is already in use.  <span class="text-danger">If this represents you, <strong>don't submit this form!</strong></span></p>
             {%- if errors.existing.admins %}
-                <p>Please contact the owners of the account at <a href="mailto:{{ errors.existing.society }}-admins@srcf.net"><strong>{{ errors.existing.society }}-admins@srcf.net</strong></a> to request your addition as an admin.</p>
+                <p>Please contact the owners of the group account at <a href="mailto:{{ errors.existing.society }}-admins@srcf.net"><strong>{{ errors.existing.society }}-admins@srcf.net</strong></a> to request your addition as an admin.</p>
                 <p>If you're unable to make contact, you may <a href="{{ DOMAIN_WEB }}/contact">request assistance</a> from the sysadmins.</p>
             {%- else %}
-                <p>This account is currently suspended as there are no remaining admins.  You may <a href="{{ DOMAIN_WEB }}/contact">request assistance</a> from the sysadmins if you wish to claim this account.</p>
+                <p>This group account is currently suspended as there are no remaining admins.  You may <a href="{{ DOMAIN_WEB }}/contact">request assistance</a> from the sysadmins if you wish to claim this account.</p>
             {%- endif %}
         </div>
     </div>
@@ -32,7 +32,7 @@
             {%- if errors.society is defined %}
                 <small class="invalid-feedback">{{ errors.society }}</small>
             {%- endif %}
-            <small class="form-text text-muted">This should be a suitable abbreviation or short name for the society, 16 or fewer lowercase letters only &ndash; e.g. "cugac" for the Cambridge University Gaelic Athletic Club.</small>
+            <small class="form-text text-muted">This should be a suitable abbreviation or short name for the group account, 16 or fewer lowercase letters only &ndash; e.g. "cugac" for the Cambridge University Gaelic Athletic Club.</small>
         </div>
     </div>
     <div class="form-group row">
@@ -42,7 +42,7 @@
             {%- if errors.description is defined %}
                 <small class="invalid-feedback">{{ errors.description }}</small>
             {%- endif %}
-            <small class="form-text text-muted">The longer name or description of the society &ndash; e.g. "CU Gaelic Athletic Club".  Abbreviation of "Cambridge University" to "CU" is encouraged.</small>
+            <small class="form-text text-muted">The longer name or description of the group &ndash; e.g. "CU Gaelic Athletic Club".  Abbreviation of "Cambridge University" to "CU" is encouraged.</small>
         </div>
     </div>
     <div class="form-group row">
@@ -52,7 +52,7 @@
             {%- if errors.admins is defined %}
                 <small class="invalid-feedback">{{ errors.admins }}</small>
             {%- endif %}
-            <small class="form-text text-muted">Please enter the CRSids of all users to be added as society admins, separated by commas.  You must include yourself in this list.</small>
+            <small class="form-text text-muted">Please enter the CRSids of all users to be added as group account admins, separated by commas.  You must include yourself in this list.</small>
         </div>
     </div>
     <input type="submit" class="btn btn-outline-primary" value="Review &amp; confirm creation">

--- a/control/templates/signup/newsoc_confirm.html
+++ b/control/templates/signup/newsoc_confirm.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 {% from "macros.html" import mem_name_crsid, soc_desc_soc %}
 
-{% set page_title = "Confirm society account creation" %}
+{% set page_title = "Confirm group account creation" %}
 
 {% block body %}
-<p>Please check any suggestions below before continuing.  An SRCF sysadmin will need to approve your request, after which you can manage your new society account from the control panel.</p>
+<p>Please check any suggestions below before continuing.  An SRCF sysadmin will need to approve your request, after which you can manage your new group account from the control panel.</p>
 <div class="card">
     <div class="card-body">
         <h5 class="card-title">Short name: <strong>{{ society }}</strong></h5>
@@ -12,7 +12,7 @@
         <p>Your admin contact address will be <strong>{{ society }}-admins@srcf.net</strong>.</p>
         <p>You will be able to create other addresses or mailing lists of the form <strong>{{ society }}-<span class="var">something</span>@srcf.net</strong>.</p>
         {% if society.endswith("soc") %}
-        <p class="text-danger">You've ended your society short name with "soc", meaning your website address will be <strong>{{ society }}.soc.srcf.net</strong>.</p>
+        <p class="text-danger">You've ended your group account short name with "soc", meaning your website address will be <strong>{{ society }}.soc.srcf.net</strong>.</p>
         {% else %}
             <p>Your website address will be <strong>{{ society }}.soc.srcf.net</strong>.</p>
         {% endif %}
@@ -23,11 +23,11 @@
     <div class="card-body">
         <h5 class="card-title">Full name: <strong>{{ description }}</strong></h5>
         {% if similar|length == 1 %}
-            <p>Possible duplicate society: {{ soc_desc_soc(similar[0]) }}</p>
+            <p>Possible duplicate group account: {{ soc_desc_soc(similar[0]) }}</p>
             <p class="text-danger">If this represents you, <strong>don't submit this form!</strong></p>
-            <p>Please contact the owners of the account at <a href="mailto:{{ similar[0].society }}-admins@srcf.net"><strong>{{ similar[0].society }}-admins@srcf.net</strong></a> to request your addition as an admin.</p>
+            <p>Please contact the owners of the group account at <a href="mailto:{{ similar[0].society }}-admins@srcf.net"><strong>{{ similar[0].society }}-admins@srcf.net</strong></a> to request your addition as an admin.</p>
         {% elif similar %}
-            <p>Possible duplicate societies:</p>
+            <p>Possible duplicate group accounts:</p>
             <ul>
                 {% for soc in similar %}
                     <li>{{ soc_desc_soc(soc) }} (<a href="mailto:{{ soc.society }}-admins@srcf.net">contact</a>)</li>
@@ -38,9 +38,9 @@
         {% endif %}
         {% if similar %}
             <p>If you're unable to make contact, you may <a href="{{ DOMAIN_WEB }}/contact">request assistance</a> from the sysadmins.</p>
-            <p>This check may not find all duplicates, check our <a href="{{ DOMAIN_WEB }}/socs/">list of all society accounts</a> for any other potential matches.</p>
+            <p>This check may not find all duplicates, check our <a href="{{ DOMAIN_WEB }}/socs/">list of all group accounts</a> for any other potential matches.</p>
         {% else %}
-            <p>No obvious duplicates found, but check our <a href="{{ DOMAIN_WEB }}/socs/">list of all society accounts</a> for any potential matches.</p>
+            <p>No obvious duplicates found, but check our <a href="{{ DOMAIN_WEB }}/socs/">list of all group accounts</a> for any potential matches.</p>
         {% endif %}
     </div>
 </div>
@@ -49,7 +49,7 @@
         {% if current_admins|length == 1 %}
         <h5 class="card-title">Administrator: {{ mem_name_crsid(current_admins[0]) }}</h5>
         <p class="text-danger">We'd <strong>strongly recommend</strong> nominating multiple account administrators before account creation.</p>
-        <p>If you leave the university or otherwise become unavailable as the sole admin of the account, it will become orphaned and liable to be taken down.</p>
+        <p>If you leave the university or otherwise become unavailable as the sole admin of the group account, it will become orphaned and liable to be taken down.</p>
         {% else %}
         <h5 class="card-title">Administrators: <strong>{{ current_admins|length }}</strong></h5>
         <ul>
@@ -57,9 +57,9 @@
                 <li>{{ mem_name_crsid(admin) }}</li>
             {% endfor %}
         </ul>
-        <p>If the last admin of the account leaves the university or otherwise becomes unavailable, the account will become orphaned and liable to be taken down.</p>
+        <p>If the last admin of the group account leaves the university or otherwise becomes unavailable, the account will become orphaned and liable to be taken down.</p>
         {% endif %}
-        <p>Ensure any successors have access to the account in good time for a smooth handover.</p>
+        <p>Ensure any successors have access to the group account in good time for a smooth handover.</p>
     </div>
 </div>
 <form action="{{ url_for('signup.newsoc') }}" method="post" class="form-submit-only">

--- a/control/templates/society/add_admin.html
+++ b/control/templates/society/add_admin.html
@@ -3,11 +3,11 @@
 
 {% block body %}
 <h2>Add administrator</h2>
-<p>Society accounts are managed by users with personal SRCF accounts.  You can elect an additional administrator, who will be given shared access to the {{ soc_desc_soc(society) }} account.</p>
+<p>Group accounts are managed by users with personal SRCF accounts.  You can elect an additional administrator, who will be given shared access to the {{ soc_desc_soc(society) }} account.</p>
 <ul>
-    <li>They will be able to edit the files of the society website.</li>
-    <li>They will be able to use their <em>personal</em> MySQL or PostgreSQL users to log into the society database.</li>
-    <li>They will not be provided with existing society account passwords (for example, databases and lists).  You can reset these from the society management page if needed.</li>
+    <li>They will be able to edit the files of the group account website.</li>
+    <li>They will be able to use their <em>personal</em> MySQL or PostgreSQL users to log into the group account database.</li>
+    <li>They will not be provided with existing group account passwords (for example, databases and lists).  You can reset these from the group account management page if needed.</li>
 </ul>
 <form action="{{ url_for('society.add_admin', society=society.society) }}" method="post">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">

--- a/control/templates/society/create_database.html
+++ b/control/templates/society/create_database.html
@@ -2,7 +2,7 @@
 
 {% block body %}
 <h2>Create {{ name }} database</h2>
-<p>A new society database{% if not soc_user %} and {{ name }} account{% endif %} will be created.</p>
+<p>A new group account database{% if not soc_user %} and {{ name }} account{% endif %} will be created.</p>
 <form action="{{ url_for('society.create_database', society=society.society, type=type) }}" method="post">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     <input type="submit" class="btn btn-outline-primary" value="Create">

--- a/control/templates/society/create_mailing_list.html
+++ b/control/templates/society/create_mailing_list.html
@@ -2,7 +2,7 @@
 
 {% block body %}
 <h2>Create mailing list</h2>
-<p>If you want to create a new mailing list, enter the list name below.  Society list addresses are of the form <strong>{{ society.society }}-<em>name</em>@srcf.net</strong>.</p>
+<p>If you want to create a new mailing list, enter the list name below.  Group account list addresses are of the form <strong>{{ society.society }}-<em>name</em>@srcf.net</strong>.</p>
 <form action="{{ url_for('society.create_mailing_list', society=society.society) }}" method="post">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     <div class="form-group">

--- a/control/templates/society/home.html
+++ b/control/templates/society/home.html
@@ -33,13 +33,13 @@
             </p>
             <hr>
             <div class="text-muted">
-                <p>Each society account administrator has full control of the account, including files in <code>/societies/{{ society.society }}</code> and <code>/public/societies/{{ society.society }}</code>, databases, and managing this list of administrators.  They also each have access to this page, and can therefore reset passwords, create mailing lists and so on.</p>
-                <p>Please ensure this list is kept up-to-date &ndash; account administrators are expected to maintain and manage operation of their society accounts, and respond to any issues or requests from the sysadmins.</p>
+                <p>Each group account administrator has full control of the account, including files in <code>/societies/{{ society.society }}</code> and <code>/public/societies/{{ society.society }}</code>, databases, and managing this list of administrators.  They also each have access to this page, and can therefore reset passwords, create mailing lists and so on.</p>
+                <p>Please ensure this list is kept up-to-date &ndash; account administrators are expected to maintain and manage operation of their group accounts, and respond to any issues or requests from the sysadmins.</p>
             </div>
             <hr>
             <div class="text-muted">
                 <p>The <strong>admin email address</strong> above forwards to all named admins.  It is the first point of contact for the sysadmins to raise issues with the account, and to pass on or request your action on third-party requests.</p>
-                <p>{% if society.role_email %}The <strong>role address</strong>{% else %}A <strong>role address</strong>, if configured,{% endif %} will be notified in the event of the society account becoming orphaned (no remaining admins), and may also be called upon if the sysadmins are unable to reach the account admins when needed.</p>
+                <p>{% if society.role_email %}The <strong>role address</strong>{% else %}A <strong>role address</strong>, if configured,{% endif %} will be notified in the event of the group account becoming orphaned (no remaining admins), and may also be called upon if the sysadmins are unable to reach the account admins when needed.</p>
             </div>
         </div>
         <div class="card-footer">
@@ -144,7 +144,7 @@
                 <hr>
             {%- endif %}
             <div class="text-muted">
-                <p>We provide society Mailman mailing lists with addresses of the form <strong>{{ society.society }}-<em>name</em>@srcf.net</strong>.</p>
+                <p>We provide group account Mailman mailing lists with addresses of the form <strong>{{ society.society }}-<em>name</em>@srcf.net</strong>.</p>
                 <p>Mailman provides its own admin panel for each list, which can be found at <strong>https://lists.srcf.net/mailman/admin/<em>list</em></strong>.</p>
             </div>
         </div>
@@ -182,11 +182,11 @@ mysql&gt;</pre>
                     <p>
                         Here, <code>-u {{ society.mysqluser }}</code> specifies the username, <code>-p</code> prompts for the corresponding password, and
                         {%- if society.mysqldbs|length == 1 %}
-                            <code>{{ society.mysqldbs[0] }}</code> at the end connects to the society database
+                            <code>{{ society.mysqldbs[0] }}</code> at the end connects to the group account database
                         {%- else %}
                             <code><em>database</em></code> at the end switches to the database of that name
                         {%- endif -%}
-                        .  On the shell, you can connect using your own account, whereas any scripts or software should use the society account.
+                        .  On the shell, you can connect using your own account, whereas any scripts or software should use the group account.
                     </p>
                 </div>
             {%- else %}
@@ -243,7 +243,7 @@ Type "help" for help.
                             If omitted, you are connected to the database that matches your logon username.
                             {%- endif %}
                         {%- endif %}
-                        Ident authentication is available, so passwords shouldn't be needed &ndash; on the shell, you can connect using your own account, whereas any scripts or software use the society account.</p>
+                        Ident authentication is available, so passwords shouldn't be needed &ndash; on the shell, you can connect using your own account, whereas any scripts or software use the group account.</p>
                     </p>
                 </div>
             {%- else %}

--- a/control/templates/society/remove_admin.html
+++ b/control/templates/society/remove_admin.html
@@ -6,19 +6,19 @@
     <h2>Remove yourself</h2>
     <p>Are you sure you want to remove yourself from the {{ soc_desc_soc(society) }} account?</p>
     <ul>
-        <li>You will no longer be able to edit the files of the society website.</li>
-        <li>You will no longer be able to use your <em>personal</em> MySQL or PostgreSQL users to log into the society database.</li>
+        <li>You will no longer be able to edit the files of the group account website.</li>
+        <li>You will no longer be able to use your <em>personal</em> MySQL or PostgreSQL users to log into the group account database.</li>
     </ul>
     {%- if society.admins|length == 1 %}
-        <p class="text-danger"><b>Warning:</b> you are the last admin of this society. If you remove yourself, {{ society.description }} will become an orphan society, and will be deleted if no new admin is appointed.</p>
+        <p class="text-danger"><b>Warning:</b> you are the last admin of this group account. If you remove yourself, {{ society.description }} will become an orphan society, and will be deleted if no new admin is appointed.</p>
     {%- endif %}
 {%- else %}
     <h2>Remove administrator</h2>
     <p>Are you sure you want to remove {{ mem_name_crsid(target) }} from the {{ soc_desc_soc(society) }} account?</p>
     <ul>
-        <li>They will no longer be able to edit the files of the society website.</li>
-        <li>They will no longer be able to use their <em>personal</em> MySQL or PostgreSQL users to log into the society database.</li>
-        <li>If they know society database passwords or society mailing list passwords then they will still know, and be able to use them. You can reset these from the society management page.</li>
+        <li>They will no longer be able to edit the files of the group account website.</li>
+        <li>They will no longer be able to use their <em>personal</em> MySQL or PostgreSQL users to log into the group account database.</li>
+        <li>If they know group account database passwords or mailing list passwords then they will still know, and be able to use them. You can reset these from the group account management page.</li>
         <li>If they could log into a CMS/webapp/Wordpress, they will continue to be able to do so. You would have to remove their account separately.</li>
         <li>It is feasible for a malicious admin to leave back-doors; contact the sysadmins if you are concerned.</li>
     </ul>

--- a/control/templates/society/reset_database_password.html
+++ b/control/templates/society/reset_database_password.html
@@ -4,7 +4,7 @@
 {% block body %}
 <h2>Reset {{ name }} password</h2>
 <p>Are you sure you want to reset the {{ name }} database password?</p>
-<p>This will affect access to {{ web_interface }}, as well as any scripts that access databases using the society account.</p>
+<p>This will affect access to {{ web_interface }}, as well as any scripts that access databases using the group account.</p>
 <form action="{{ url_for('society.reset_database_password', society=society.society, type=type) }}" method="post">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     <input type="submit" class="btn btn-outline-primary" value="Confirm">

--- a/control/templates/society/update_role_email.html
+++ b/control/templates/society/update_role_email.html
@@ -3,7 +3,7 @@
 
 {% block body %}
 <h2>Update role email</h2>
-<p>A role address, if configured, will be notified in the event of the society account becoming orphaned (no remaining admins), and may also be called upon if the sysadmins are unable to reach the account admins when needed.</p>
+<p>A role address, if configured, will be notified in the event of the group account becoming orphaned (no remaining admins), and may also be called upon if the sysadmins are unable to reach the account admins when needed.</p>
 <p>This can be a committee role address, or a shared mailbox managed by the organisation related to the account.  This should be a long-lived address, that does not change as individual admins come and go &ndash; <strong>please do not use the address of a single person</strong>, which would be liable to become outdated.</p>
 <p>Note that this is not a replacement for timely handovers of the <code>{{ society.society }}</code> account; please ensure that the list of admins remains up-to-date, in order to avoid possible interruption of service.</p>
 <form action="{{ url_for('society.update_role_email', society=society.society) }}" method="post">

--- a/control/webapp/inspect_services.py
+++ b/control/webapp/inspect_services.py
@@ -1,6 +1,6 @@
 """
-inspect_services: look up accounts, mailing lists, etc. that a Member or
-Society has on the SRCF
+inspect_services: look up accounts, mailing lists, etc. that a User or
+Group has on the SRCF
 """
 
 import os

--- a/control/webapp/signup.py
+++ b/control/webapp/signup.py
@@ -141,15 +141,15 @@ def newsoc():
                                 .format(", ".join(sorted(x.crsid for x in member_admins if x not in current_admins))))
 
         if not values["society"]:
-            errors["society"] = "Please enter a society short name."
+            errors["society"] = "Please enter a group account short name."
         elif len(values["society"]) > 16:
-            errors["society"] = "Society short names must be no longer than 16 characters."
+            errors["society"] = "Group account short names must be no longer than 16 characters."
         elif not SOC_SOCIETY_RE.match(values["society"]):
-            errors["society"] = "Society short names may only contain lowercase letters."
+            errors["society"] = "Group account short names may only contain lowercase letters."
 
         keywords = make_keywords(values["description"])
         if not values["description"]:
-            errors["description"] = "Please enter the full name of the society."
+            errors["description"] = "Please enter the full name of the group."
         elif ILLEGAL_NAME_RE.search(values["description"]):
             errors["description"] = ILLEGAL_NAME_ERR
         elif not keywords:
@@ -161,13 +161,13 @@ def newsoc():
             pass
         else:
             errors["existing"] = soc
-            errors["society"] = "A society with this short name already exists."
+            errors["society"] = "A group account with this short name already exists."
 
         soc = sess.query(Society).filter(func.lower(Society.description) == values["description"].lower()).first()
         if soc:
             if "existing" not in errors:
                 errors["existing"] = soc
-            errors["description"] = "A society with this full name already exists."
+            errors["description"] = "A group account with this full name already exists."
 
         similar = []
         if "existing" not in errors:
@@ -175,7 +175,7 @@ def newsoc():
                 words = make_keywords(soc.description)
                 if keywords == words:
                     errors["existing"] = soc
-                    errors["description"] = "A society with a matching full name already exists."
+                    errors["description"] = "A group account with a matching full name already exists."
                     break
                 elif keywords <= words:
                     similar.append(soc)

--- a/control/webapp/utils.py
+++ b/control/webapp/utils.py
@@ -202,7 +202,7 @@ def create_job_maybe_email_and_redirect(cls, *args, **kwargs):
         if j.row.args:
             body = yaml.dump(j.row.args, default_flow_style=False) + "\n" + body
         if isinstance(j, SocietyJob) and j.society is not None and j.society.danger:
-            body = "WARNING: The target society has its danger flag set.\n\n" + body
+            body = "WARNING: The target group account has its danger flag set.\n\n" + body
         if j.owner is not None and j.owner.danger:
             body = "WARNING: The job owner has their danger flag set.\n\n" + body
         subject = "[Control Panel] Job #{0.job_id} {0.state} -- {0}".format(j)


### PR DESCRIPTION
Only the text references have been changed. No changes have been made to refactor society variables or page names.