### PR TITLE
Use url_for to point to webapp URLs [hotfix]

### DIFF
--- a/control/templates/base.html
+++ b/control/templates/base.html
@@ -85,7 +85,7 @@
                 <div>
                     <h5>Membership</h5>
                     <ul class="fa-ul mb-0">
-                        <li><a href="{{ DOMAIN_CONTROL }}/signup"><i class="fa fa-li fa-user"></i> Join the SRCF</a>
+                        <li><a href="{{ url_for('signup.signup') }}"><i class="fa fa-li fa-user"></i> Join the SRCF</a>
                         </li>
                         <li><a href="{{ DOMAIN_WEB }}/services"><i class="fa fa-li fa-cubes"></i> List of services</a>
                         </li>


### PR DESCRIPTION
PR #7 might have been pulled in a bit too hastily...

DOMAIN_CONTROL was mistakenly copied from an SSI template for the main website; the concept doesn't exist in control panel itself.  We change to use `url_for` again.