### PR TITLE
Job withdrawals, member/group renames, domain and job UI improvements

### DIFF
--- a/control/static/script.js
+++ b/control/static/script.js
@@ -17,4 +17,36 @@ $(document).ready(function() {
         });
         ev.preventDefault();
     });
+    $(".alert[data-job-status]").each(function(i, flash) {
+        const job_url = flash.dataset.jobStatus;
+        const job_text = $(".job-text", flash).text();
+        let retry = 1;
+        function poll() {
+            const req = $.ajax(job_url);
+            req.done(function(job) {
+                retry = 1;
+                if (job.state === "done") {
+                    $(flash).removeClass("alert-primary").addClass("alert-success");
+                    $(".message", flash).text("has completed.  Reload to see any changes.");
+                    return;
+                } else if (job.state === "failed") {
+                    $(flash).removeClass("alert-primary").addClass("alert-danger");
+                    $(".message", flash).text("has failed to complete.  The sysadmins have been notified.");
+                    return;
+                } else if (job.state === "pending") {
+                    $(flash).removeClass("alert-primary").addClass("alert-warning");
+                    $(".message", flash).text("is awaiting approval from the sysadmins.");
+                } else if (job.state === "running") {
+                    $(flash).removeClass("alert-warning").addClass("alert-primary");
+                    $(".message", flash).text("is currently runnning, and will be completed shortly.");
+                }
+                setTimeout(poll, 2000);
+            });
+            req.fail(function() {
+                retry *= 2;
+                setTimeout(poll, 2000 * retry);
+            });
+        }
+        poll();
+    });
 });

--- a/control/static/script.js
+++ b/control/static/script.js
@@ -20,11 +20,12 @@ $(document).ready(function() {
     $(".alert[data-job-status]").each(function(i, flash) {
         const job_url = flash.dataset.jobStatus;
         const job_text = $(".job-text", flash).text();
-        let retry = 1;
+        let retry = 2;
         function poll() {
             const req = $.ajax(job_url);
             req.done(function(job) {
-                retry = 1;
+                retry = 2;
+                let delay = 2;
                 if (job.state === "done") {
                     $(flash).removeClass("alert-primary").addClass("alert-success");
                     $(".message", flash).text("has completed.  Reload to see any changes.");
@@ -33,18 +34,19 @@ $(document).ready(function() {
                     $(flash).removeClass("alert-primary").addClass("alert-danger");
                     $(".message", flash).text("has failed to complete.  The sysadmins have been notified.");
                     return;
-                } else if (job.state === "pending") {
+                } else if (job.state === "unapproved") {
                     $(flash).removeClass("alert-primary").addClass("alert-warning");
                     $(".message", flash).text("is awaiting approval from the sysadmins.");
+                    delay = 30;
                 } else if (job.state === "running") {
                     $(flash).removeClass("alert-warning").addClass("alert-primary");
                     $(".message", flash).text("is currently runnning, and will be completed shortly.");
                 }
-                setTimeout(poll, 2000);
+                setTimeout(poll, 1000 * delay);
             });
             req.fail(function() {
-                retry *= 2;
-                setTimeout(poll, 2000 * retry);
+                setTimeout(poll, 1000 * retry);
+                retry = Math.min(retry * 2, 30);
             });
         }
         poll();

--- a/control/templates/admin/status.html
+++ b/control/templates/admin/status.html
@@ -9,13 +9,15 @@
 
 {% block body %}
 {{ super() }}
-{%- if danger %}
+{%- if job.has_danger %}
     <p class="text-danger">
         <i class="fa fa-exclamation-triangle"></i>
-        {%- if danger | length > 1 %}
-            Both {{ " and " | join(danger) }} have their danger flags set.
-        {%- else %}
-            {{ danger[0] }}'s danger flag is set.
+        {%- if for_society and job.owner_has_danger and job.society_has_danger %}
+            Both {{ job.owner_crsid }} and {{ job.society_society }} have their danger flags set.
+        {%- elif job.owner_has_danger %}
+            Job owner {{ job.owner_crsid }}'s danger flag is set.
+        {%- elif for_society and job.society_has_danger %}
+            The group {{ job.society_society }}'s danger flag is set.
         {%- endif %}
     </p>
 {%- endif %}

--- a/control/templates/admin/status.html
+++ b/control/templates/admin/status.html
@@ -9,9 +9,22 @@
 
 {% block body %}
 {{ super() }}
+{%- if danger %}
+    <p class="text-danger">
+        <i class="fa fa-exclamation-triangle"></i>
+        {%- if danger | length > 1 %}
+            Both {{ " and " | join(danger) }} have their danger flags set.
+        {%- else %}
+            {{ danger[0] }}'s danger flag is set.
+        {%- endif %}
+    </p>
+{%- endif %}
+{%- if notes %}
+    <p class="text-info"><i class="fa fa-info-circle"></i> Check notes before approving.</p>
+{%- endif %}
 {%- if job.state == "unapproved" %}
     <p>
-        <a class="btn btn-outline-primary" href="{{ url_for('admin.set_state', id=job.job_id, action='approve') }}">Approve</a>
+        <a class="btn btn-outline-{% if danger %}danger{% elif notes %}info{% else %}primary{% endif %}" href="{{ url_for('admin.set_state', id=job.job_id, action='approve') }}">Approve</a>
         <a class="btn btn-outline-secondary" href="{{ url_for('admin.set_state', id=job.job_id, action='reject') }}">Reject</a>
     </p>
 {%- elif job.state == "queued" %}
@@ -39,15 +52,17 @@
 <h3>Notes</h3>
 <ul>
     {%- for entry in notes %}
-    <li><a href="#log-{{ entry.log_id }}">{{ entry.time }}</a>: {{ entry.message }}</li>
+    <li>
+        {{ entry.raw }}<br>
+        &mdash; {{ entry.message }}, <a href="#log-{{ entry.log_id }}">{{ entry.time.strftime("%Y-%m-%d %H:%M:%S") }}</a>
+    </li>
     {%- endfor %}
 </ul>
 {% endif %}
-<h3>Add note</h3>
 <form action="{{ url_for('admin.add_note', job_id=job.job_id) }}" method="post">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     <p>
-        <textarea name="text" class="form-control job-note-entry" placeholder="Enter text here." rows="5"></textarea>
+        <textarea name="text" class="form-control job-note-entry" placeholder="Add a note..." rows="5"></textarea>
     </p>
     <p>
         <input type="submit" class="btn btn-outline-primary" value="Add">
@@ -87,14 +102,14 @@
         {% if not has_create_log %}
             <tr class="job-log-entry">
                 <td>created</td>
-                <td>{{ job.created_at or "&mdash;" }}</td>
+                <td>{{ job.created_at.strftime("%Y-%m-%d %H:%M:%S") if job.created_at else "&mdash;" }}</td>
                 <td>&mdash;</td>
             </tr>
         {% endif %}
         {% for entry in log %}
             <tr class="job-log-entry" id="log-{{ entry.log_id }}">
                 <td>{{ entry.type }}</td>
-                <td>{{ entry.time }}</td>
+                <td>{{ entry.time.strftime("%Y-%m-%d %H:%M:%S") if entry.time else "&mdash;" }}</td>
                 <td>
                     {{ entry.message|default("&mdash;"|safe, true) }}
                     {% if entry.raw %}

--- a/control/templates/base.html
+++ b/control/templates/base.html
@@ -56,18 +56,20 @@
             <small class="text-muted">{{ page_subtitle }}</small>
             {%- endif %}
         </h2>
-        {%- endif %}
-        {% with messages = get_flashed_messages() %}
-        {% for message in messages %}
-        <div class="alert alert-info alert-dismissible fade show" role="alert">
+      {%- endif %}
+      {%- for category, message in get_flashed_messages(with_categories=True) %}
+        <div class="alert alert-primary alert-dismissible show" role="alert"{% if category == "job-created" %} data-job-status="{{ url_for("jobs.status_json", id=message[0]) }}"{% endif %}>
+          {%- if category == "raw" %}
             {{ message }}
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
+          {%- elif category == "job-created" %}
+            {%- set job_id, job_text = message %}
+            <a class="job-text" href="{{ url_for("jobs.status", id=job_id) }}">Job #{{ job_id }}: {{ job_text }}</a>
+            <span class="message">has been submitted.</span>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          {%- endif %}
         </div>
-        {% endfor %}
-        {% endwith %}
-        {% block body %}{% endblock %}
+      {%- endfor %}
+      {% block body %}{% endblock %}
     </main>
     <div id="action-modal" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog" role="document">

--- a/control/templates/base.html
+++ b/control/templates/base.html
@@ -51,6 +51,7 @@
             <a href="{{ page_parent }}" title="Back"><i class="fa fa-arrow-left"></i></a>
             {%- endif %}
             {{ page_title }}
+            {% block page_title_extra %}{% endblock %}
             {%- if page_subtitle is defined %}
             <small class="text-muted">{{ page_subtitle }}</small>
             {%- endif %}

--- a/control/templates/macros.html
+++ b/control/templates/macros.html
@@ -5,13 +5,13 @@
 
 {% macro vhost(domain, wild=false, https=true) %}
 <a href="http{% if https %}s{% endif %}://{{ domain }}">
-    {%- if wild %}
-        <i class="fa fa-indent" aria-label="Wildcard subdomains for {{ domain }}" title="Wildcard subdomains"></i>
-    {%- endif %}
-    {%- if https %}
-        <i class="fa fa-lock" aria-label="HTTPS activated for {{ domain }}" title="HTTPS activated"></i>
-    {%- endif %}
-    {{ domain }}
+    {%- if wild -%}
+        <i class="fa fa-indent" aria-label="Wildcard subdomains for {{ domain }}" title="Wildcard subdomains"></i>&nbsp;
+    {%- endif -%}
+    {%- if https -%}
+        <i class="fa fa-lock" aria-label="HTTPS activated for {{ domain }}" title="HTTPS activated"></i>&nbsp;
+    {%- endif -%}
+    {{- domain }}
 </a>
 {% endmacro %}
 

--- a/control/templates/member/add_vhost.html
+++ b/control/templates/member/add_vhost.html
@@ -5,7 +5,7 @@
 <form action="{{ url_for('member.add_vhost') }}" method="post">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     <p>You can serve your SRCF website from a custom domain (or a subdomain) once it resolves to our server.  Don't include www here &ndash; the addition of e.g. <em>example.com</em> will be able to serve both that and <em>www.example.com</em>, as long as both resolve to us.</p>
-    <p>Note that <strong>you must already own the domain</strong> (typically by buying it from a registrar) &ndash; the SRCF is not a registrar and cannot do this for you.  You'll also need to <a href="https://wiki.srcf.net/DomainsAndHTTPS" target="_blank">configure DNS records</a> so that your domain resolves to us.</p>
+    <p>Note that <strong>you must already own the domain</strong> (typically by buying it from a registrar) &ndash; the SRCF is not a registrar and cannot do this for you.  You'll also need to <a href="https://docs.srcf.net/web-hosting/domains.html" target="_blank">configure DNS records</a> so that your domain resolves to us.</p>
     <div class="form-group">
         <input name="domain" type="text" class="form-control{% if "domain" in errors %} is-invalid{% endif %}" value="{{ domain }}" placeholder="Domain or subdomain" autofocus required>
         {%- if "domain" in errors %}

--- a/control/templates/member/home.html
+++ b/control/templates/member/home.html
@@ -84,11 +84,7 @@ The NIS password has been changed on pip.srcf.net.</pre>
             <h4 class="card-title">Website</h4>
             <ul class="list-unstyled">
                 <li>
-                    {%- if member.website.state in ("legacy", "legacyredirect") %}
-                        Primary address:
-                    {%- else %}
-                        Address:
-                    {%- endif %}
+                    Default address:
                     {%- if member.website.exists %}
                         {{ vhost(member.crsid + ".user.srcf.net") }}
                     {%- else %}
@@ -106,12 +102,16 @@ The NIS password has been changed on pip.srcf.net.</pre>
                 <table class="table table-sm">
                     <thead>
                         <tr>
-                            <th>Custom domain</th>
+                            <th>Domain</th>
                             <th>Document root</th>
                             <th></th>
                         </tr>
                     </thead>
                     <tbody>
+                        <tr>
+                            <td>{{ vhost(member.crsid + ".user.srcf.net") }}</td>
+                            <td><em>Same as web root</em></td>
+                        </tr>
                         {%- for domain in member.website.vhosts|sort(attribute="domain") %}
                             <tr>
                                 <td>

--- a/control/templates/member/home.html
+++ b/control/templates/member/home.html
@@ -120,7 +120,12 @@ The NIS password has been changed on pip.srcf.net.</pre>
             {%- endif %}
             <hr>
             <div class="text-muted">
-                {%- if not member.website.exists %}
+                {%- if member.website.exists %}
+                    <p>A certificate for encrypted (HTTPS) access to your website is automatically provided for the domain
+                    <i>{{ member.crsid }}.user.srcf.net</i>.  For custom domains, you can opt in for a certificate, which
+                    will be issued within 24 hours of request.</p>
+                    <p aria-hidden=true>Domains with certificates already issued are marked with <i class="fa fa-lock text-dark"></i>.</p>
+                {%- else %}
                     <p>You don't currently have a website set up.</p>
                 {%- endif %}
                 <p>Upload pages or files to your web root directory, and they'll be published on your website.  Note that newly-uploaded websites may take up to 20 minutes before they start serving.</p>
@@ -134,6 +139,7 @@ The NIS password has been changed on pip.srcf.net.</pre>
         </div>
         <div class="card-footer">
             <a href="{{ url_for('member.add_vhost') }}" rel="modal" class="btn btn-outline-primary">Add custom domain</a>
+            <a href="https://srcf-admin.soc.srcf.net/lets-encrypt/" target="_blank" class="btn btn-outline-primary">Request HTTPS certificate</a>
         </div>
     </div>
     <div class="card">

--- a/control/templates/member/home.html
+++ b/control/templates/member/home.html
@@ -5,6 +5,10 @@
 {% set page_subtitle = member.crsid %}
 {% set page_parent = url_for('home.home') %}
 
+{% block page_title_extra -%}
+<small><a rel="modal" href="{{ url_for('member.update_name') }}" aria-label="Update registered name" title="Update registered name"><i class="fa fa-pencil"></i></a></small>
+{%- endblock %}
+
 {% block body %}
 <p>Date joined: <b>{{ member.joined.strftime('%B %G') }}</b></p>
 <p><a href="{{ url_for('jobs.home') }}" class="btn btn-outline-secondary">Job history</a></p>

--- a/control/templates/member/home.html
+++ b/control/templates/member/home.html
@@ -12,6 +12,19 @@
 {% block body %}
 <p>Date joined: <b>{{ member.joined.strftime('%B %G') }}</b></p>
 <p><a href="{{ url_for('jobs.home') }}" class="btn btn-outline-secondary">Job history</a></p>
+{%- if pending %}
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title">Jobs pending approval</h4>
+            <p>The following jobs have been received, but are awaiting approval from a system administrator.  You may need to check your emails for any follow-up questions or actions before they can be approved.</p>
+            <ul>
+                {%- for job in pending %}
+                <li><a href="{{ url_for('jobs.status', id=job.job_id) }}">{{ job }}</a></li>
+                {%- endfor %}
+            </ul>
+        </div>
+    </div>
+{%- endif %}
 <div class="card-columns">
     <div class="card">
         <div class="card-body">

--- a/control/templates/member/update_name.html
+++ b/control/templates/member/update_name.html
@@ -4,19 +4,20 @@
 <h2>Update registered name</h2>
 <p>You can update the name we have on record for you.  This will also update the name on your Unix user record (in the <a href="https://en.wikipedia.org/wiki/Gecos_field" target="_blank">GECOS field</a>).</p>
 <form action="{{ url_for('member.update_name') }}" method="post">
-    {%- if 'general' in errors %}
-    <strong><small class="invalid-feedback">{{ errors.general }}</small></strong>
-    {%- endif %}
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     <div class="form-group">
-        <input name="preferred_name" type="preferred_name" class="form-control{% if 'preferred_name' in errors %} is-invalid{% endif %}" value="{{ preferred_name }}" placeholder="First name" required>
+        <input name="preferred_name" type="preferred_name" class="form-control{% if 'preferred_name' in errors or 'general' in errors %} is-invalid{% endif %}" value="{{ preferred_name }}" placeholder="First name" required>
         {%- if 'preferred_name' in errors %}
         <small class="invalid-feedback">{{ errors.preferred_name }}</small>
         {%- endif %}
     </div>
     <div class="form-group">
-        <input name="surname" type="surname" class="form-control{% if 'surname' in errors %} is-invalid{% endif %}" value="{{ surname }}" placeholder="Surname" required>
+        <input name="surname" type="surname" class="form-control{% if 'surname' in errors or 'general' in errors %} is-invalid{% endif %}" value="{{ surname }}" placeholder="Surname" required>
         {%- if 'surname' in errors %}
         <small class="invalid-feedback">{{ errors.surname }}</small>
+        {%- endif %}
+        {%- if 'general' in errors %}
+        <small class="invalid-feedback">{{ errors.general }}</small>
         {%- endif %}
     </div>
     <input type="submit" class="btn btn-outline-primary" value="Update">

--- a/control/templates/member/update_name.html
+++ b/control/templates/member/update_name.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h2>Update registered name</h2>
+<p>You can update the name we have on record for you.  This will also update the name on your Unix user record (in the <a href="https://en.wikipedia.org/wiki/Gecos_field" target="_blank">GECOS field</a>).</p>
+<form action="{{ url_for('member.update_name') }}" method="post">
+    {%- if 'general' in errors %}
+    <strong><small class="invalid-feedback">{{ errors.general }}</small></strong>
+    {%- endif %}
+    <div class="form-group">
+        <input name="preferred_name" type="preferred_name" class="form-control{% if 'preferred_name' in errors %} is-invalid{% endif %}" value="{{ preferred_name }}" placeholder="First name" required>
+        {%- if 'preferred_name' in errors %}
+        <small class="invalid-feedback">{{ errors.preferred_name }}</small>
+        {%- endif %}
+    </div>
+    <div class="form-group">
+        <input name="surname" type="surname" class="form-control{% if 'surname' in errors %} is-invalid{% endif %}" value="{{ surname }}" placeholder="Surname" required>
+        {%- if 'surname' in errors %}
+        <small class="invalid-feedback">{{ errors.surname }}</small>
+        {%- endif %}
+    </div>
+    <input type="submit" class="btn btn-outline-primary" value="Update">
+    <a href="{{ url_for('member.home') }}" data-dismiss="modal" class="btn btn-outline-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/control/templates/shared/add_vhost_test.html
+++ b/control/templates/shared/add_vhost_test.html
@@ -5,13 +5,13 @@
 {% macro info(v, record="") %}
     {% if v is none %}
         <p>We couldn't connect to this domain.</p>
-        <p>This may mean there are no <a href="https://wiki.srcf.net/DomainsAndHTTPS" target="_blank">{{ record }} DNS records</a> present, or the domain currently resolves to another server that isn't responding.</p>
+        <p>This may mean there are no <a href="https://docs.srcf.net/web-hosting/domains.html" target="_blank">{{ record }} DNS records</a> present, or the domain currently resolves to another server that isn't responding.</p>
     {% elif v %}
         <p>This domain resolves correctly to the SRCF webserver, and is ready to serve your site.</p>
     {% else %}
         <p>This domain currently resolves to a different server.</p>
         <p>If you are using your domain to host an existing website, you can continue to register your domain here, and switch over when ready.</p>
-        <p>Otherwise, this may be a holding page provided by your domain registrar.  You should check that your <a href="https://wiki.srcf.net/DomainsAndHTTPS" target="_blank">{{ record }} DNS records</a> are configured correctly.  Remember that DNS changes may take time to propagate.</p>
+        <p>Otherwise, this may be a holding page provided by your domain registrar.  You should check that your <a href="https://docs.srcf.net/web-hosting/domains.html" target="_blank">{{ record }} DNS records</a> are configured correctly.  Remember that DNS changes may take time to propagate.</p>
     {% endif %}
 {% endmacro %}
 

--- a/control/templates/society/add_vhost.html
+++ b/control/templates/society/add_vhost.html
@@ -5,7 +5,7 @@
 <form action="{{ url_for('society.add_vhost', society=society.society) }}" method="post">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     <p>You can serve your SRCF website from a custom domain (or a subdomain) once it resolves to our server.  Don't include www here &ndash; the addition of e.g. <em>example.com</em> will be able to serve both that and <em>www.example.com</em>, as long as both resolve to us.</p>
-    <p>Note that <strong>you must already own the domain</strong> (typically by buying it from a registrar) &ndash; the SRCF is not a registrar and cannot do this for you.  You'll also need to <a href="https://wiki.srcf.net/DomainsAndHTTPS" target="_blank">configure DNS records</a> so that your domain resolves to us.</p>
+    <p>Note that <strong>you must already own the domain</strong> (typically by buying it from a registrar) &ndash; the SRCF is not a registrar and cannot do this for you.  You'll also need to <a href="https://docs.srcf.net/web-hosting/domains.html" target="_blank">configure DNS records</a> so that your domain resolves to us.</p>
     <div class="form-group">
         <input name="domain" type="text" class="form-control{% if "domain" in errors %} is-invalid{% endif %}" value="{{ domain }}" placeholder="Domain or subdomain" autofocus required>
         {%- if "domain" in errors %}

--- a/control/templates/society/home.html
+++ b/control/templates/society/home.html
@@ -5,6 +5,10 @@
 {% set page_subtitle = society.society %}
 {% set page_parent = url_for('home.home') %}
 
+{% block page_title_extra -%}
+<small><a rel="modal" href="{{ url_for('society.update_description', society=society.society) }}" aria-label="Update description" title="Update description"><i class="fa fa-pencil"></i></a></small>
+{%- endblock %}
+
 {% block body %}
 <p>Date created: <b>{{ society.joined.strftime('%B %G') }}</b></p>
 <p><a href="{{ url_for('jobs.society_home', name=society.society) }}" class="btn btn-outline-secondary">Job history</a></p>

--- a/control/templates/society/home.html
+++ b/control/templates/society/home.html
@@ -105,7 +105,12 @@
             {%- endif %}
             <hr>
             <div class="text-muted">
-                {%- if not society.website.exists %}
+                {%- if society.website.exists %}
+                    <p>A certificate for encrypted (HTTPS) access to your website is automatically provided for the domain
+                    <i>{{ society.society }}.soc.srcf.net</i>.  For custom domains, you can opt in for a certificate, which
+                    will be issued within 24 hours of request.</p>
+                    <p aria-hidden=true>Domains with certificates already issued are marked with <i class="fa fa-lock text-dark"></i>.</p>
+                {%- else %}
                     <p>You don't currently have a website set up.</p>
                 {%- endif %}
                 <p>Upload pages or files to your web root directory, and they'll be published on your website.  Note that newly-uploaded websites may take up to 20 minutes before they start serving.</p>
@@ -119,6 +124,7 @@
         </div>
         <div class="card-footer">
             <a href="{{ url_for('society.add_vhost', society=society.society) }}" rel="modal" class="btn btn-outline-primary">Add custom domain</a>
+            <a href="https://srcf-admin.soc.srcf.net/lets-encrypt/" target="_blank" class="btn btn-outline-primary">Request HTTPS certificate</a>
         </div>
     </div>
     <div class="card">

--- a/control/templates/society/home.html
+++ b/control/templates/society/home.html
@@ -12,6 +12,19 @@
 {% block body %}
 <p>Date created: <b>{{ society.joined.strftime('%B %G') }}</b></p>
 <p><a href="{{ url_for('jobs.society_home', name=society.society) }}" class="btn btn-outline-secondary">Job history</a></p>
+{%- if pending %}
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title">Jobs pending approval</h4>
+            <p>The following jobs have been received, but are awaiting approval from a system administrator.  You may need to check your emails for any follow-up questions or actions before they can be approved.</p>
+            <ul>
+                {%- for job in pending %}
+                <li><a href="{{ url_for('jobs.status', id=job.job_id) }}">{{ job }}</a></li>
+                {%- endfor %}
+            </ul>
+        </div>
+    </div>
+{%- endif %}
 <div class="card-columns">
     <div class="card">
         <div class="card-body">

--- a/control/templates/society/update_description.html
+++ b/control/templates/society/update_description.html
@@ -4,6 +4,7 @@
 <h2>Update description</h2>
 <p>You can update the description (or "long name") for the <code>{{ society.society }}</code> account.  This will also update the name on its Unix user record (in the <a href="https://en.wikipedia.org/wiki/Gecos_field" target="_blank">GECOS field</a>).</p>
 <form action="{{ url_for('society.update_description', society=society.society) }}" method="post">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     <div class="form-group">
         <input name="description" type="description" class="form-control{% if error %} is-invalid{% endif %}" value="{{ description }}" placeholder="Description" required>
         {%- if error %}

--- a/control/templates/society/update_description.html
+++ b/control/templates/society/update_description.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h2>Update description</h2>
+<p>You can update the description (or "long name") for the <code>{{ society.society }}</code> account.  This will also update the name on its Unix user record (in the <a href="https://en.wikipedia.org/wiki/Gecos_field" target="_blank">GECOS field</a>).</p>
+<form action="{{ url_for('society.update_description', society=society.society) }}" method="post">
+    <div class="form-group">
+        <input name="description" type="description" class="form-control{% if error %} is-invalid{% endif %}" value="{{ description }}" placeholder="Description" required>
+        {%- if error %}
+        <small class="invalid-feedback">{{ error }}</small>
+        {%- endif %}
+    </div>
+    <input type="submit" class="btn btn-outline-primary" value="Update">
+    <a href="{{ url_for('society.home', society=society.society) }}" data-dismiss="modal" class="btn btn-outline-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/control/webapp/admin.py
+++ b/control/webapp/admin.py
@@ -43,6 +43,7 @@ per_page = 25
 @bp.route('/admin/jobs/running',    defaults={"state": "running"})
 @bp.route('/admin/jobs/done',       defaults={"state": "done"})
 @bp.route('/admin/jobs/failed',     defaults={"state": "failed"})
+@bp.route('/admin/jobs/withdrawn',  defaults={"state": "withdrawn"})
 def view_jobs(state):
 
     # Best-effort parsing of ?page= falling back to 1 in all error cases
@@ -87,7 +88,7 @@ def status(id):
 
 
 _actions = {
-    "reject": ("rejected", "unapproved", "failed"),
+    "reject": ("rejected", "unapproved", "withdrawn"),
     "approve": ("approved", "unapproved", "queued"),
     "cancel": ("cancelled", "queued", "failed"),
     "abort": ("aborted", "running", "failed"),

--- a/control/webapp/admin.py
+++ b/control/webapp/admin.py
@@ -79,11 +79,19 @@ def status(id):
     notes = [x for x in log if x.type == "note"]
 
     job_home_url = url_for('admin.view_jobs', state=job.state)
-    for_society = isinstance(job, SocietyJob) and job.owner.crsid != utils.auth.principal
-    owner_in_context = job.society_society if isinstance(job, SocietyJob) else job.owner_crsid
+    for_society = isinstance(job, SocietyJob)
+
+    owner_in_context = job.owner_crsid
+    danger = []
+    if job.owner.danger:
+        danger.append(job.owner_crsid)
+    if for_society:
+        owner_in_context = job.society_society
+        if job.society and job.society.danger:
+            danger.append(job.society_society)
 
     return render_template("admin/status.html", job=job, notes=notes, log=log, job_home_url=job_home_url,
-                           for_society=for_society, owner_in_context=owner_in_context,
+                           for_society=for_society, owner_in_context=owner_in_context, danger=danger,
                            principal=utils.raven.principal, has_create_log=has_create_log)
 
 

--- a/control/webapp/admin.py
+++ b/control/webapp/admin.py
@@ -130,5 +130,5 @@ def add_note(job_id):
         if text:
             sess.add(JobLog(job_id=job_id, type="note", level="info", time=datetime.now(),
                             message="Note added by {}".format(utils.auth.principal), raw=text))
-            flash("Note successfully added.")
+            flash("Note successfully added.", "raw")
         return redirect(url_for('admin.status', id=job_id))

--- a/control/webapp/admin.py
+++ b/control/webapp/admin.py
@@ -82,16 +82,11 @@ def status(id):
     for_society = isinstance(job, SocietyJob)
 
     owner_in_context = job.owner_crsid
-    danger = []
-    if job.owner.danger:
-        danger.append(job.owner_crsid)
     if for_society:
         owner_in_context = job.society_society
-        if job.society and job.society.danger:
-            danger.append(job.society_society)
 
     return render_template("admin/status.html", job=job, notes=notes, log=log, job_home_url=job_home_url,
-                           for_society=for_society, owner_in_context=owner_in_context, danger=danger,
+                           for_society=for_society, owner_in_context=owner_in_context,
                            principal=utils.raven.principal, has_create_log=has_create_log)
 
 

--- a/control/webapp/jobs.py
+++ b/control/webapp/jobs.py
@@ -113,7 +113,7 @@ def withdraw(id):
     log = JobLog(job_id=id, type="progress", level="info", time=datetime.now(),
                  message=log_message)
 
-    job.set_state("failed", log_message)
+    job.set_state("withdrawn", log_message)
 
     sess.add(log)
     sess.add(job.row)

--- a/control/webapp/member.py
+++ b/control/webapp/member.py
@@ -45,6 +45,34 @@ def reactivate():
     else:
         return render_template("member/reactivate.html", member=mem, email=email, error=error)
 
+@bp.route("/member/name", methods=["GET", "POST"])
+def update_name():
+    crsid, mem = find_member()
+
+    preferred_name = mem.preferred_name
+    surname = mem.surname
+
+    errors = {}
+
+    if request.method == "POST":
+        preferred_name = request.form.get("preferred_name", "").strip()
+        surname = request.form.get("surname", "").strip()
+
+        if mem.preferred_name == preferred_name and mem.surname == surname:
+            errors['general'] = "We already have this name for you."
+        if not mem.preferred_name:
+            errors['preferred_name'] = "You need to enter a preferred (first) name."
+        if not mem.surname:
+            errors['surname'] = "You need to enter a surname."
+
+        if not errors:
+            return create_job_maybe_email_and_redirect(
+                        jobs.UpdateName, member=mem,
+                        preferred_name=preferred_name, surname=surname)
+
+    return render_template("member/update_name.html", member=mem, errors=errors,
+                           preferred_name=preferred_name, surname=surname)
+
 @bp.route("/member/email", methods=["GET", "POST"])
 def update_email_address():
     crsid, mem = find_member()

--- a/control/webapp/member.py
+++ b/control/webapp/member.py
@@ -25,7 +25,8 @@ def home():
 
     inspect_services.lookup_all(mem)
 
-    return render_template("member/home.html", member=mem)
+    pending = [job for job in jobs.Job.find_by_user(sess, utils.auth.principal) if job.state == "unapproved"]
+    return render_template("member/home.html", member=mem, pending=pending)
 
 @bp.route("/reactivate", methods=["GET", "POST"])
 def reactivate():

--- a/control/webapp/society.py
+++ b/control/webapp/society.py
@@ -48,6 +48,29 @@ def home(society):
 
     return render_template("society/home.html", member=mem, society=soc)
 
+@bp.route("/societies/<society>/description", methods=["GET", "POST"])
+def update_description(society):
+    mem, soc = find_mem_society(society)
+
+    description = soc.description
+    error = None
+    if request.method == "POST":
+        description = request.form.get("description", "").strip() or None
+        if not description:
+            error = "You can't set an empty description."
+        elif description != soc.description:
+            error = "That's the description we have already."
+
+        if not error:
+            return create_job_maybe_email_and_redirect(
+                jobs.UpdateSocietyDescription,
+                requesting_member=mem,
+                society=soc,
+                description=description
+            )
+    else:
+        return render_template("society/update_description.html", society=soc, description=description, error=error)
+
 @bp.route("/societies/<society>/roleemail", methods=["GET", "POST"])
 def update_role_email(society):
     mem, soc = find_mem_society(society)

--- a/control/webapp/society.py
+++ b/control/webapp/society.py
@@ -8,7 +8,6 @@ from .utils import srcf_db_sess as sess
 from .utils import parse_domain_name, create_job_maybe_email_and_redirect, find_mem_society
 from . import utils
 from srcf.controllib import jobs
-from srcf.controllib.jobs import Job
 from srcf.database import Domain
 from srcf import domains
 
@@ -46,7 +45,8 @@ def home(society):
     inspect_services.lookup_all(mem)
     inspect_services.lookup_all(soc)
 
-    return render_template("society/home.html", member=mem, society=soc)
+    pending = [job for job in jobs.Job.find_by_society(sess, soc.society) if job.state == "unapproved"]
+    return render_template("society/home.html", member=mem, society=soc, pending=pending)
 
 @bp.route("/societies/<society>/description", methods=["GET", "POST"])
 def update_description(society):

--- a/control/webapp/society.py
+++ b/control/webapp/society.py
@@ -58,7 +58,7 @@ def update_description(society):
         description = request.form.get("description", "").strip() or None
         if not description:
             error = "You can't set an empty description."
-        elif description != soc.description:
+        elif description == soc.description:
             error = "That's the description we have already."
 
         if not error:
@@ -68,8 +68,8 @@ def update_description(society):
                 society=soc,
                 description=description
             )
-    else:
-        return render_template("society/update_description.html", society=soc, description=description, error=error)
+
+    return render_template("society/update_description.html", society=soc, description=description, error=error)
 
 @bp.route("/societies/<society>/roleemail", methods=["GET", "POST"])
 def update_role_email(society):

--- a/control/webapp/utils.py
+++ b/control/webapp/utils.py
@@ -208,7 +208,12 @@ def create_job_maybe_email_and_redirect(cls, *args, **kwargs):
         subject = "[Control Panel] Job #{0.job_id} {0.state} -- {0}".format(j)
         srcf.mail.mail_sysadmins(subject, body)
 
-    return flask.redirect(flask.url_for('jobs.status', id=j.job_id))
+    flask.flash((j.job_id, str(j)), "job-created")
+    if isinstance(j, SocietyJob):
+        url = flask.url_for("society.home", society=j.society_society)
+    else:
+        url = flask.url_for("member.home")
+    return flask.redirect(url)
 
 def find_member(allow_inactive=False):
     """ Gets a CRSID and member object from the Raven authentication data """


### PR DESCRIPTION
* Withdrawing a job places it in its own state, separate from failed.  There's a bonus post-merge migration task to find jobs with a message of "job withdrawn" and update their state to match.
* Users can now update their registered name and group account descriptions.
* Jobs pending approval are listed on member and group homes, in order to dissuade duplicate job submissions.
* For browsers with JavaScript enabled, an alert bar appears on job submission and will auto-refresh with the job's current state.
* Admins will be warned of danger flags and notes before approving a job.

Depends on SRCF/srcf-python#5. 