### PR TITLE
Add admin user impersonation header

### DIFF
--- a/control/templates/base.html
+++ b/control/templates/base.html
@@ -45,6 +45,13 @@
         </div>
     </nav>
     <main role="main" class="container flex-shrink-0 my-4">
+        {%- set crsid = effective_crsid() %}
+        {%- if auth.principal != crsid %}
+            <div class="alert alert-danger">
+                <i class="fa fa-user-secret"></i>
+                Hello <strong>{{ auth.principal }}</strong>.  You are currently impersonating <strong>{{ crsid }}</strong>.
+            </div>
+        {%- endif %}
         {%- if page_title is defined %}
         <h2>
             {%- if page_parent is defined %}

--- a/control/templates/signup/signup.html
+++ b/control/templates/signup/signup.html
@@ -7,7 +7,6 @@
 <p>Note that to assist your application, we have attempted to guess values based on information available to anyone on the CUDN. These are not stored until you complete the application form and give us explicit permission to do so.</p>
 <form action="{{ url_for('signup.signup') }}" method="post">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-    {% if force_signup_form|default(false) %}<input type="hidden" name="force-signup-form" value="1">{% endif %}
     <div class="form-group row">
         <label class="col-lg-2 col-md-3 col-sm-4 col-form-label">CRSid</label>
         <div class="col-lg-10 col-md-9 col-sm-8">

--- a/control/webapp/home.py
+++ b/control/webapp/home.py
@@ -8,13 +8,11 @@ bp = Blueprint("home", __name__)
 
 @bp.route('/')
 def home():
-    crsid = utils.auth.principal
+    mem = utils.effective_member(allow_inactive=True, allow_unregistered=True)
 
-    try:
-        mem = utils.get_member(crsid)
-    except KeyError:
+    if not mem:
         return redirect(url_for('signup.signup'))
-    if not mem.user:
+    elif not mem.user:
         return redirect(url_for('member.reactivate'))
 
     inspect_services.lookup_all(mem, fast=True)

--- a/control/webapp/utils.py
+++ b/control/webapp/utils.py
@@ -266,6 +266,8 @@ def effective_member(allow_inactive=False, allow_unregistered=False):
     crsid = auth.principal
     try:
         mem = get_member(crsid)
+        if not mem.member:
+            raise KeyError(crsid)
     except KeyError:
         if allow_unregistered:
             return None
@@ -280,6 +282,8 @@ def effective_member(allow_inactive=False, allow_unregistered=False):
         return mem
     try:
         alt = get_member(override)
+        if not alt.member:
+            raise KeyError(crsid)
     except KeyError:
         if allow_unregistered:
             return None


### PR DESCRIPTION
This allows sysadmins to view the Control Panel as another user by setting a header on requests (using e.g. a browser extension).  This is useful for debugging any issues users are facing that are tricky to reproduce on our own accounts.

The changes here replace `find_member()` and its calls with `effective_crsid()` and `effective_member()`, which are both aware of the header and return the appropriate user information.