### PR TITLE
Use Job's managed state transitions

### DIFF
--- a/control/templates/jobs/status.html
+++ b/control/templates/jobs/status.html
@@ -3,7 +3,7 @@
 {% set page_parent = url_for('jobs.society_home', name=owner_in_context) if for_society else url_for('jobs.home') %}
 {% block body %}
 {{ super() }}
-{%- if member and job.state in ('queued', 'unapproved') %}
+{%- if member and job.state == 'unapproved' %}
 <p>
     <a class="btn btn-outline-primary" href="{{ url_for('jobs.withdraw', id=job.job_id) }}">Withdraw request</a>
 </p>


### PR DESCRIPTION
Further to SRCF/srcf-python#12, this swaps out the current job transition logic with the `srcf.controllib` implementation.