### PR TITLE
Fix up database creation and password-reset logic

### DIFF
--- a/control/templates/member/home.html
+++ b/control/templates/member/home.html
@@ -243,10 +243,8 @@ mysql&gt;</pre>
         <div class="card-footer">
             {%- if member.mysqluser %}
                 <a href="{{ url_for('member.reset_password', type='mysql') }}" rel="modal" class="btn btn-outline-primary">Reset password</a>
-            {%- elif member.mysqldbs %}
-                <a href="{{ url_for('member.create_database_account', type='mysql') }}" rel="modal" class="btn btn-outline-primary">Create personal account</a>
             {%- endif %}
-            {%- if not member.mysqldbs %}
+            {%- if not (member.mysqluser and member.mysqldbs) %}
                 <a href="{{ url_for('member.create_database', type='mysql') }}" rel="modal" class="btn btn-outline-primary">Create personal database{% if not member.mysqluser %} and user{% endif %}</a>
             {%- endif %}
         </div>

--- a/control/templates/society/home.html
+++ b/control/templates/society/home.html
@@ -222,12 +222,10 @@ mysql&gt;</pre>
         </div>
         <div class="card-footer">
             {%- if society.mysqluser %}
-            <a href="{{ url_for('society.reset_database_password', society=society.society, type='mysql') }}" rel="modal" class="btn btn-outline-primary">Reset password</a>
-            {%- elif society.mysqldbs %}
-            <p>You have a MySQL database but no MySQL account. Please contact the sysadmins to use MySQL.</p>
+                <a href="{{ url_for('society.reset_database_password', society=society.society, type='mysql') }}" rel="modal" class="btn btn-outline-primary">Reset password</a>
             {%- endif %}
-            {%- if not society.mysqldbs %}
-            <a href="{{ url_for('society.create_database', society=society.society, type='mysql') }}" rel="modal" class="btn btn-outline-primary">Create society database{% if not society.mysqluser %} and user{% endif %}</a>
+            {%- if not (society.mysqluser and society.mysqldbs) %}
+                <a href="{{ url_for('society.create_database', society=society.society, type='mysql') }}" rel="modal" class="btn btn-outline-primary">Create society database{% if not society.mysqluser %} and user{% endif %}</a>
             {%- endif %}
         </div>
     </div>


### PR DESCRIPTION
Previously, the case where a database exists but the user doesn't was handled by the "reset password" job.  Since switching to SRCFLib, this should be done with the "create user and database" job (which will skip either of the two steps as needed).

We also tend to link users to the database password reset page directly, which doesn't work if they don't have an account yet, so this change introduces redirects to the opposite of create/reset when appropriate.